### PR TITLE
Add link to register page

### DIFF
--- a/ckanext/openafrica/templates/header.html
+++ b/ckanext/openafrica/templates/header.html
@@ -56,6 +56,7 @@
               </li>
             {% else %}
                 <li>{% link_for _('Log in'), controller='user', action='login' %}</li>
+                <li>{% link_for _('Register'), controller='user', action='register' %}</li>
             {% endif %}
           </ul>
         </div>


### PR DESCRIPTION
### What does this PR do?
This PR adds a link to the register page on the menu bar for users that are not logged in. After user logs in, the `Register` link is no longer visible just like the `Log in` link.

### Related Issue
#30 

### How does the change look?
For a user who is not logged in...

![screen shot 2017-09-13 at 1 19 22 pm](https://user-images.githubusercontent.com/26964086/30695894-bc78e89c-9ed1-11e7-8ad9-0724fbb2c2bb.png)


For a logged in user...

![screen shot 2017-09-21 at 1 36 48 pm](https://user-images.githubusercontent.com/26964086/30696011-0cc3ce84-9ed2-11e7-975a-ba04b7fe119c.png)




