### PR TITLE
add custom robots.txt to block indexing /user and AI bots

### DIFF
--- a/ckanext/openafrica/blueprint.py
+++ b/ckanext/openafrica/blueprint.py
@@ -10,7 +10,7 @@ def static_path(path):
     return render_path
 
 def robots_txt():
-    '''display robots.txt'''
+    """display robots.txt"
     resp = make_response(render("home/robots.txt"))
     resp.headers["Content-Type"] = "text/plain; charset=utf-8"
     return resp

--- a/ckanext/openafrica/blueprint.py
+++ b/ckanext/openafrica/blueprint.py
@@ -16,7 +16,8 @@ rules = [
     ("/about/moderation-policy", "moderation", static_path("home/about/moderation.html")),
     ("/about/faq", "faq", static_path("home/about/faq.html")),
     ("/about/privacy", "privacy", static_path("home/about/privacy.html")),
-    ("/about/contact-us", "contact", static_path("home/about/contact.html"))
+    ("/about/contact-us", "contact", static_path("home/about/contact.html")),
+    ("/robots.txt", "robots_txt", static_path("robots.txt"))
 ]
 
 for rule in rules:

--- a/ckanext/openafrica/blueprint.py
+++ b/ckanext/openafrica/blueprint.py
@@ -1,4 +1,4 @@
-from flask import Blueprint
+from flask import Blueprint, make_response
 from ckan.plugins.toolkit import render
 
 openafrica = Blueprint("openafrica", __name__)
@@ -9,6 +9,12 @@ def static_path(path):
 
     return render_path
 
+def robots_txt():
+    '''display robots.txt'''
+    resp = make_response(render('home/robots.txt'))
+    resp.headers['Content-Type'] = "text/plain; charset=utf-8"
+    return resp
+
 rules = [
     ("/about/terms-and-conditions", "toc", static_path("home/about/toc.html")),
     ("/about/accessibility", "accessibility", static_path("home/about/accessibility.html")),
@@ -17,7 +23,7 @@ rules = [
     ("/about/faq", "faq", static_path("home/about/faq.html")),
     ("/about/privacy", "privacy", static_path("home/about/privacy.html")),
     ("/about/contact-us", "contact", static_path("home/about/contact.html")),
-    ("/robots.txt", "robots_txt", static_path("robots.txt"))
+    ("/robots.txt", robots_txt)
 ]
 
 for rule in rules:

--- a/ckanext/openafrica/blueprint.py
+++ b/ckanext/openafrica/blueprint.py
@@ -11,7 +11,7 @@ def static_path(path):
 
 def robots_txt():
     '''display robots.txt'''
-    resp = make_response(render('home/robots.txt'))
+    resp = make_response(render('robots.txt'))
     resp.headers['Content-Type'] = "text/plain; charset=utf-8"
     return resp
 

--- a/ckanext/openafrica/blueprint.py
+++ b/ckanext/openafrica/blueprint.py
@@ -11,7 +11,7 @@ def static_path(path):
 
 def robots_txt():
     '''display robots.txt'''
-    resp = make_response(render("robots.txt"))
+    resp = make_response(render("home/robots.txt"))
     resp.headers["Content-Type"] = "text/plain; charset=utf-8"
     return resp
 

--- a/ckanext/openafrica/blueprint.py
+++ b/ckanext/openafrica/blueprint.py
@@ -11,8 +11,8 @@ def static_path(path):
 
 def robots_txt():
     '''display robots.txt'''
-    resp = make_response(render('robots.txt'))
-    resp.headers['Content-Type'] = "text/plain; charset=utf-8"
+    resp = make_response(render("robots.txt"))
+    resp.headers["Content-Type"] = "text/plain; charset=utf-8"
     return resp
 
 rules = [

--- a/ckanext/openafrica/blueprint.py
+++ b/ckanext/openafrica/blueprint.py
@@ -23,7 +23,7 @@ rules = [
     ("/about/faq", "faq", static_path("home/about/faq.html")),
     ("/about/privacy", "privacy", static_path("home/about/privacy.html")),
     ("/about/contact-us", "contact", static_path("home/about/contact.html")),
-    ("/robots.txt", robots_txt)
+    ("/robots.txt", "robots_txt", robots_txt())
 ]
 
 for rule in rules:

--- a/ckanext/openafrica/blueprint.py
+++ b/ckanext/openafrica/blueprint.py
@@ -23,7 +23,7 @@ rules = [
     ("/about/faq", "faq", static_path("home/about/faq.html")),
     ("/about/privacy", "privacy", static_path("home/about/privacy.html")),
     ("/about/contact-us", "contact", static_path("home/about/contact.html")),
-    ("/robots.txt", "robots_txt", robots_txt())
+    ("/robots.txt", "robots_txt", robots_txt)
 ]
 
 for rule in rules:

--- a/ckanext/openafrica/templates/home/robots.txt
+++ b/ckanext/openafrica/templates/home/robots.txt
@@ -1,15 +1,6 @@
-# Crawl-delay Specifies the minimum interval (in seconds)
-#for a robot to wait after loading one page, before starting to load another.
-Crawl-delay: 10
+{% ckan_extends %}
 
-# Disallow specifies the paths that are not allowed to be crawled by the robot.
-User-agent: *
-Disallow: /dataset/rate/
-Disallow: /revision/
-Disallow: /dataset/*/history
-Disallow: /api/
-Disallow: /user/
-
+{% block additional_user_agents -%}
 # Amazonbot
 User-agent: Amazonbot
 Disallow: /
@@ -74,5 +65,6 @@ Disallow: /
 User-agent: PerplexityBot
 Disallow: /
 
-
 # Generatedy by RoboShield (https://roboshield.trustlab.africa)
+
+{%- endblock %}

--- a/ckanext/openafrica/templates/robots.txt
+++ b/ckanext/openafrica/templates/robots.txt
@@ -1,0 +1,78 @@
+# Crawl-delay Specifies the minimum interval (in seconds)
+#for a robot to wait after loading one page, before starting to load another.
+Crawl-delay: 10
+
+# Disallow specifies the paths that are not allowed to be crawled by the robot.
+User-agent: *
+Disallow: /dataset/rate/
+Disallow: /revision/
+Disallow: /dataset/*/history
+Disallow: /api/
+Disallow: /user/
+
+# Amazonbot
+User-agent: Amazonbot
+Disallow: /
+
+# anthropic-ai
+User-agent: anthropic-ai
+Disallow: /
+
+# Applebot
+User-agent: Applebot
+Disallow: /
+
+# Applebot-Extended
+User-agent: Applebot-Extended
+Disallow: /
+
+# Bytespider
+User-agent: Bytespider
+Disallow: /
+
+# CCBot
+User-agent: CCBot
+Disallow: /
+
+# ChatGPT-User
+User-agent: ChatGPT-User
+Disallow: /
+
+# Claude-Web
+User-agent: Claude-Web
+Disallow: /
+
+# ClaudeBot
+User-agent: ClaudeBot
+Disallow: /
+
+# cohere-ai
+User-agent: cohere-ai
+Disallow: /
+
+# Diffbot
+User-agent: Diffbot
+Disallow: /
+
+# FacebookBot
+User-agent: FacebookBot
+Disallow: /
+
+# Google-Extended
+User-agent: Google-Extended
+Disallow: /
+
+# GPTBot
+User-agent: GPTBot
+Disallow: /
+
+# omgili
+User-agent: omgili
+Disallow: /
+
+# PerplexityBot
+User-agent: PerplexityBot
+Disallow: /
+
+
+# Generatedy by RoboShield (https://roboshield.trustlab.africa)

--- a/ckanext/openafrica/templates/user/list.html
+++ b/ckanext/openafrica/templates/user/list.html
@@ -1,0 +1,42 @@
+{% extends "page.html" %}
+
+{% block meta %}
+  {{ super() }}
+  <meta name="robots" content="noindex, nofollow" />
+{% endblock %}
+
+{% block subtitle %}{{ _('All Users') }}{% endblock %}
+
+{% block breadcrumb_content %}
+  <li class="active">{{ h.nav_link(_('Users'), named_route='user.index') }}</li>
+{% endblock %}
+
+{% block primary_content %}
+  <article class="module">
+    <div class="module-content">
+      <h1 class="page-heading">
+        {% block page_heading %}{{ _('Users') }}{% endblock %}
+      </h1>
+      {% if h.check_access('sysadmin', context) %}
+      {% block users_list %}
+        <ul class="user-list">
+          {% block users_list_inner %}
+            {% for user in page.items %}
+             <li>{{ h.linked_user(user.name, maxlength=20) }} - {{ user.email }}</li>
+            {% endfor %}
+          {% endblock %}
+        </ul>
+      {% endblock %}
+      {% else %}
+        <p>{{ _('You do not have permission to view the list of users.') }}</p>
+      {% endif %}
+    </div>
+    {% block page_pagination %}
+      {{ page.pager(q=q, order_by=order_by) }}
+    {% endblock %}
+  </article>
+{% endblock %}
+
+{% block secondary_content %}
+  {% snippet 'user/snippets/user_search.html', q=q %}
+{% endblock %}

--- a/ckanext/openafrica/templates/user/list.html
+++ b/ckanext/openafrica/templates/user/list.html
@@ -17,7 +17,7 @@
       <h1 class="page-heading">
         {% block page_heading %}{{ _('Users') }}{% endblock %}
       </h1>
-      {% if h.check_access('sysadmin', context) %}
+      {% if c.userobj.sysadmin %}
       {% block users_list %}
         <ul class="user-list">
           {% block users_list_inner %}

--- a/ckanext/openafrica/templates/user/read_base.html
+++ b/ckanext/openafrica/templates/user/read_base.html
@@ -1,0 +1,6 @@
+{% ckan_extends %}
+
+{% block meta %}
+  {{ super() }}
+  <meta name="robots" content="noindex, nofollow" />
+{% endblock %}


### PR DESCRIPTION
This PR introduces
1. Creates a custom `robots.txt` overriding CKAN's[ default `robots.txt` ](https://github.com/salsadigitalauorg/ckan/blob/3c67ea2be1938f88575c5fc049231e463aa4be6f/ckan/templates/home/robots.txt#L1)
We'd like to block indexing &/ crawling on `/user` and block generic AI bots not in Cloudflare's Verified bot's [list](https://radar.cloudflare.com/traffic/verified-bots)
2. Adds a `noindex` and `nofollow` tags on the User List page to block search engines from indexing CKAN User's list. 
3. Only admin users should view the user's list and show username + email